### PR TITLE
Update BayesianTools version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,7 +41,7 @@ Imports:
     lhs,
     lifecycle,
     lubridate,
-    Matrix (= 1.6.5)
+    Matrix (== 1.6.5),
     methods,
     nloptr,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -41,6 +41,7 @@ Imports:
     lhs,
     lifecycle,
     lubridate,
+    Matrix (= 1.6.5)
     methods,
     nloptr,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ BugReports: https://github.com/SticsRPacks/CroptimizR/issues
 Depends:
     R (>= 4.0.0)
 Imports:
+    Matrix,
     BayesianTools,
     crayon,
     doParallel,
@@ -41,7 +42,6 @@ Imports:
     lhs,
     lifecycle,
     lubridate,
-    Matrix (== 1.6.5),
     methods,
     nloptr,
     purrr,
@@ -67,6 +67,7 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
+    github::cran/Matrix@1.6-5,
     github::hol430/ApsimOnR,
     github::SticsRPacks/CroPlotR@*release,
     github::SticsRPacks/SticsOnR@*release,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,7 +66,6 @@ Suggests:
 VignetteBuilder: 
     knitr
 Remotes:
-    github::florianhartig/BayesianTools/BayesianTools@c953ae2bf8c112f95fdda1a35b2ff33a1f00c208,
     github::hol430/ApsimOnR,
     github::SticsRPacks/CroPlotR@*release,
     github::SticsRPacks/SticsOnR@*release,


### PR DESCRIPTION
An old specific version of the BayesianTools package was forced to be installed due to temporary problems of dependencies installation. the problem is now solved and the last versiob of BayesianTools is installed.
However, the last version of a dependency of BayesianTools, the package Matrix version 1.7.0, is now requiring R>=4.4.0. To keep the possibility to use older versions of R with CroptimizR, Matrix has been added in the DESCRIPTION file as a direct dependency for CroptimizR and is automatically installed with its previous version (1.6-5) in case it is not yet installed. 