### PR TITLE
Update README.md -> R build status badge only for main now

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CroptimizR
 state and is being actively
 developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R build
-status](https://github.com/SticsRPacks/CroptimizR/workflows/R-CMD-check/badge.svg)](https://github.com/SticsRPacks/CroptimizR/actions)
+status](https://github.com/SticsRPacks/CroptimizR/workflows/R-CMD-check/badge.svg?branch=main)](https://github.com/SticsRPacks/CroptimizR/actions)
 [![Codecov test
 coverage](https://codecov.io/gh/SticsRPacks/CroptimizR/branch/master/graph/badge.svg)](https://codecov.io/gh/SticsRPacks/CroptimizR?branch=master)
 [![DOI](https://zenodo.org/badge/187874725.svg)](https://zenodo.org/badge/latestdoi/187874725)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ CroptimizR
 state and is being actively
 developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![R build
-status](https://github.com/SticsRPacks/CroptimizR/workflows/R-CMD-check/badge.svg?branch=main)](https://github.com/SticsRPacks/CroptimizR/actions)
+status](https://github.com/SticsRPacks/CroptimizR/actions/workflows/check-standard.yaml/badge.svg?branch=main)](https://github.com/SticsRPacks/CroptimizR/actions)
 [![Codecov test
 coverage](https://codecov.io/gh/SticsRPacks/CroptimizR/branch/master/graph/badge.svg)](https://codecov.io/gh/SticsRPacks/CroptimizR?branch=master)
 [![DOI](https://zenodo.org/badge/187874725.svg)](https://zenodo.org/badge/latestdoi/187874725)


### PR DESCRIPTION
The R cmd check status badge points to whatever was the last execution, so it meant that if a PR was failing, the badge was failing. This badge is meant to show if the main branch is passing, so here's an update for the badge to point only to the checks on main.