### PR TITLE
Update dependency to R

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -33,7 +33,7 @@ jobs:
             }
           - {
               os: ubuntu-latest,
-              r: "4.0.0",
+              r: "4.1.0",
               rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest",
             }
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ URL: https://github.com/SticsRPacks/CroptimizR,
     https://doi.org/10.5281/zenodo.4066451
 BugReports: https://github.com/SticsRPacks/CroptimizR/issues
 Depends:
-    R (>= 4.0.0)
+    R (>= 4.1.0)
 Imports:
     Matrix,
     BayesianTools,


### PR DESCRIPTION
Some dependencies require R > 4.0.0 

  * see #25 
  * see https://github.com/SticsRPacks/CroptimizR/actions/runs/14749511677/job/41405860937 : "scales: Needs R >= 4.1"

=> identify minimum R version and update github action and description file.