### PR TITLE
Update check-standard.yaml for fixing error in macos tests

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -43,6 +43,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - uses: r-hub/actions/setup-r-sysreqs@v1 # Install and setup R system dependencies on macOS.
+        with:
+          type: full
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -54,17 +54,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          pak-version: rc
-          # about pak-version:
-          # Ubuntu doesn't install the proper version of XML see https://github.com/r-lib/actions/issues/559. Remove when fixed.
-          # see also: https://stackoverflow.com/questions/73243945/pkgdown-action-failing-at-build-xml
-          extra-packages: |
-            any::rcmdcheck
+          extra-packages: any::rcmdcheck
           needs: check
-          exclude: ape
-
-      - name: Install ape 5.6
-        run: Rscript -e "install.packages('https://cran.r-project.org/src/contrib/Archive/ape/ape_5.6.tar.gz', repos = NULL, type = 'source')"
 
       - name: Install custom R dependencies
         run: |
@@ -75,6 +66,7 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
 
   # Trigger CI using SticsRTest
   trigger-SticsRTest:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: r-hub/actions/setup-r-sysreqs@v1 # Install and setup R system dependencies on macOS.
+        with:
+          type: full
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true


### PR DESCRIPTION
We have an issue with the macos runners that can't build Matrix:


```
  * checking for file ‘/private/var/folders/hn/k7g0_sh57112t0xtjxcjcm5r0000gn/T/RtmpAahalA/X/Matrix/cran-Matrix-8f0083c/DESCRIPTION’ ... OK
  * preparing ‘Matrix’:
  * checking DESCRIPTION meta-information ... OK
  * cleaning src
  * running ‘cleanup’
  * installing the package to process help pages
        -----------------------------------
  * installing *source* package ‘Matrix’ ...
  ** this is package ‘Matrix’ version ‘1.6-5’
  file ‘build/Matrix.pdf’ is missing
  ** using staged installation
  ** libs
  using C compiler: ‘Apple clang version 15.0.0 (clang-1500.3.9.4)’
  using SDK: ‘’
  clang -arch arm64 -I"/Library/Frameworks/R.framework/Resources/include" -DNDEBUG -I./SuiteSparse_config -DNTIMER  -I/opt/R/arm64/include   -fvisibility=hidden -fPIC  -falign-functions=64 -Wall -g -O2  -Wall -pedantic -c Csparse.c -o Csparse.o
  In file included from Csparse.c:1:
  ./Mdefines.h:41:11: fatal error: 'libintl.h' file not found
  # include <libintl.h>
            ^~~~~~~~~~~
  1 error generated.
  make: *** [Csparse.o] Error 1
  ERROR: compilation failed for package ‘Matrix’
  * removing ‘/private/var/folders/hn/k7g0_sh57112t0xtjxcjcm5r0000gn/T/RtmpJ9h3Zs/Rinstf91514d9fe2/Matrix’
        -----------------------------------
  ERROR: package installation failed
  Error: 
  ! error in pak subprocess
  Caused by error in `stop_task_package_build(state, worker)`:
  ! Failed to create source package Matrix from source tree at
  '/var/folders/hn/k7g0_sh57112t0xtjxcjcm5r0000gn/T//RtmpAahalA/filef056463d463/src/contrib/Matrix_1.6-5_8f0083c.tar.gz-t'
```

This is probably coming from the version of `ape` that we force and that makes all other packages to use an older version:

```
  + ape              5.8-1      🔧 ⬇
```

So I'm removing the forcing that we do on ape to see if it fixes the error.
