### PR TITLE
Fix apsim vignette

### DIFF
--- a/vignettes/ApsimX_parameter_estimation_simple_case.Rmd
+++ b/vignettes/ApsimX_parameter_estimation_simple_case.Rmd
@@ -14,6 +14,8 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 params:
   eval_rmd: FALSE
+  eval_auto_vignette: TRUE     # automatic execution of the vignette
+  result_path: "D:/Home/sbuis/Documents/GitHub/CroptimizR/vignettes"
 ---
 
 

--- a/vignettes/ApsimX_parameter_estimation_simple_case.Rmd
+++ b/vignettes/ApsimX_parameter_estimation_simple_case.Rmd
@@ -71,7 +71,7 @@ if (!require("tidyr")) {
 # DEFINE THE PATH TO THE LOCALLY INSTALLED VERSION OF APSIM (should be something
 # like C:/path/to/apsimx/bin/Models.exe on windows, and /usr/local/bin/Models
 # on linux)
-apsimx_path <- "D:\\Home\\sbuis\\Documents\\OUTILS-INFORMATIQUE\\APSIM2021.01.20.5937\\Bin\\Models.exe"
+apsimx_path <- "D:\\Home\\sbuis\\Documents\\OUTILS-INFORMATIQUE\\APSIM2025.04.7734.0\\bin\\Models.exe"
 ```
 
 


### PR DESCRIPTION
I tested the vignette with a newer version of Apsim and ApsimOnR (see #45)

Some parameters of the vignette were not defined => fixed
