### PR TITLE
Fix citation.cff file formating

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,526 +4,525 @@
 # -----------------------------------------------------------
 
 cff-version: 1.2.0
-message: 'To cite package "CroptimizR" in publications use:'
+message: "To cite package \"CroptimizR\" in publications use:"
 type: software
-title: 'CroptimizR: A Package to Estimate Parameters of Crop Models'
+title: "CroptimizR: A Package to Estimate Parameters of Crop Models"
 version: 1.0.0
-abstract: The purpose of CroptimizR is to provide functions for
-    estimating crop model parameters from observations of their simulated
-    variables. This process is often referred to as calibration. For that, it
-    offers a generic framework for linking crop models with up-to-date and
-    ad-hoc algorithms, as well as a choice of goodness-of-fit criteria and
-    additional features adapted to the problem of crop model calibration
-	  including AgMIP calibration protocol and user-defined sequential multi-step workflow.
-    It facilitates the comparison of different types of methods on
-    different models.
+abstract: The purpose of CroptimizR is to provide functions for estimating crop
+  model parameters from observations of their simulated variables. This process
+  is often referred to as calibration. For that, it offers a generic framework
+  for linking crop models with up-to-date and ad-hoc algorithms, as well as a
+  choice of goodness-of-fit criteria and additional features adapted to the
+  problem of crop model calibration including AgMIP calibration protocol and
+  user-defined sequential multi-step workflow. It facilitates the comparison of
+  different types of methods on different models.
 authors:
-- family-names: Buis
-  given-names: Samuel
-  email: samuel.buis@inrae.fr
-  orcid: https://orcid.org/0000-0002-8676-5447
-- family-names: Lecharpentier
-  given-names: Patrice
-  email: patrice.lecharpentier@inrae.fr
-  orcid: https://orcid.org/0000-0002-4044-4322
-- family-names: Vezy
-  given-names: Remi
-  email: remi.vezy@cirad.fr
-  orcid: https://orcid.org/0000-0002-0808-1461
-- family-names: Giner
-  given-names: Michel
-  email: michel.giner@cirad.fr
-  orcid: https://orcid.org/0000-0002-9310-2377
+  - family-names: Buis
+    given-names: Samuel
+    email: samuel.buis@inrae.fr
+    orcid: https://orcid.org/0000-0002-8676-5447
+  - family-names: Lecharpentier
+    given-names: Patrice
+    email: patrice.lecharpentier@inrae.fr
+    orcid: https://orcid.org/0000-0002-4044-4322
+  - family-names: Vezy
+    given-names: Remi
+    email: remi.vezy@cirad.fr
+    orcid: https://orcid.org/0000-0002-0808-1461
+  - family-names: Giner
+    given-names: Michel
+    email: michel.giner@cirad.fr
+    orcid: https://orcid.org/0000-0002-9310-2377
 repository-code: https://github.com/SticsRPacks/CroptimizR
 url: https://doi.org/10.5281/zenodo.4066451
-date-released: '2023-01-06'
+date-released: "2023-01-06"
 contact:
-- family-names: Buis
-  given-names: Samuel
-  email: samuel.buis@inrae.fr
-  orcid: https://orcid.org/0000-0002-8676-5447
+  - family-names: Buis
+    given-names: Samuel
+    email: samuel.buis@inrae.fr
+    orcid: https://orcid.org/0000-0002-8676-5447
 keywords:
-- crop-model
-- parameter-estimation
-- sensitivity-analysis
-- uncertainty-analysis
+  - crop-model
+  - parameter-estimation
+  - sensitivity-analysis
+  - uncertainty-analysis
 references:
-- type: software
-  title: 'R: A Language and Environment for Statistical Computing'
-  notes: Depends
-  url: https://www.R-project.org/
-  authors:
-  - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2023'
-  institution:
-    name: R Foundation for Statistical Computing
-  version: '>= 4.0.0'
-- type: software
-  title: BayesianTools
-  abstract: 'BayesianTools: General-Purpose MCMC and SMC Samplers and Tools for Bayesian
-    Statistics'
-  notes: Imports
-  url: https://github.com/florianhartig/BayesianTools
-  repository: https://CRAN.R-project.org/package=BayesianTools
-  authors:
-  - family-names: Hartig
-    given-names: Florian
-    email: florian.hartig@biologie.uni-regensburg.de
-    orcid: https://orcid.org/0000-0002-6255-9059
-  - family-names: Minunno
-    given-names: Francesco
-  - family-names: Paul
-    given-names: Stefan
-  year: '2023'
-- type: software
-  title: crayon
-  abstract: 'crayon: Colored Terminal Output'
-  notes: Imports
-  url: https://github.com/r-lib/crayon#readme
-  repository: https://CRAN.R-project.org/package=crayon
-  authors:
-  - family-names: Csárdi
-    given-names: Gábor
-    email: csardi.gabor@gmail.com
-  year: '2023'
-- type: software
-  title: doParallel
-  abstract: 'doParallel: Foreach Parallel Adaptor for the ''parallel'' Package'
-  notes: Imports
-  url: https://github.com/RevolutionAnalytics/doparallel
-  repository: https://CRAN.R-project.org/package=doParallel
-  authors:
-  - family-names: Corporation
-    given-names: Microsoft
-  - family-names: Weston
-    given-names: Steve
-  year: '2023'
-- type: software
-  title: dplyr
-  abstract: 'dplyr: A Grammar of Data Manipulation'
-  notes: Imports
-  url: https://dplyr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=dplyr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: François
-    given-names: Romain
-    orcid: https://orcid.org/0000-0002-2444-4226
-  - family-names: Henry
-    given-names: Lionel
-  - family-names: Müller
-    given-names: Kirill
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Vaughan
-    given-names: Davis
-    email: davis@posit.co
-    orcid: https://orcid.org/0000-0003-4777-038X
-  year: '2023'
-- type: software
-  title: ggplot2
-  abstract: 'ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics'
-  notes: Imports
-  url: https://ggplot2.tidyverse.org
-  repository: https://CRAN.R-project.org/package=ggplot2
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: Chang
-    given-names: Winston
-    orcid: https://orcid.org/0000-0002-1576-2126
-  - family-names: Henry
-    given-names: Lionel
-  - family-names: Pedersen
-    given-names: Thomas Lin
-    email: thomas.pedersen@posit.co
-    orcid: https://orcid.org/0000-0002-5147-4711
-  - family-names: Takahashi
-    given-names: Kohske
-  - family-names: Wilke
-    given-names: Claus
-    orcid: https://orcid.org/0000-0002-7470-9261
-  - family-names: Woo
-    given-names: Kara
-    orcid: https://orcid.org/0000-0002-5125-4188
-  - family-names: Yutani
-    given-names: Hiroaki
-    orcid: https://orcid.org/0000-0002-3385-7233
-  - family-names: Dunnington
-    given-names: Dewey
-    orcid: https://orcid.org/0000-0002-9415-4582
-  year: '2023'
-- type: software
-  title: lhs
-  abstract: 'lhs: Latin Hypercube Samples'
-  notes: Imports
-  url: https://github.com/bertcarnell/lhs
-  repository: https://CRAN.R-project.org/package=lhs
-  authors:
-  - family-names: Carnell
-    given-names: Rob
-    email: bertcarnell@gmail.com
-  year: '2023'
-- type: software
-  title: lifecycle
-  abstract: 'lifecycle: Manage the Life Cycle of your Package Functions'
-  notes: Imports
-  url: https://lifecycle.r-lib.org/
-  repository: https://CRAN.R-project.org/package=lifecycle
-  authors:
-  - family-names: Henry
-    given-names: Lionel
-    email: lionel@rstudio.com
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-    orcid: https://orcid.org/0000-0003-4757-117X
-  year: '2023'
-- type: software
-  title: lubridate
-  abstract: 'lubridate: Make Dealing with Dates a Little Easier'
-  notes: Imports
-  url: https://lubridate.tidyverse.org
-  repository: https://CRAN.R-project.org/package=lubridate
-  authors:
-  - family-names: Spinu
-    given-names: Vitalie
-    email: spinuvit@gmail.com
-  - family-names: Grolemund
-    given-names: Garrett
-  - family-names: Wickham
-    given-names: Hadley
-  year: '2023'
-- type: software
-  title: methods
-  abstract: 'R: A Language and Environment for Statistical Computing'
-  notes: Imports
-  authors:
-  - name: R Core Team
-  location:
-    name: Vienna, Austria
-  year: '2023'
-  institution:
-    name: R Foundation for Statistical Computing
-- type: software
-  title: nloptr
-  abstract: 'nloptr: R Interface to NLopt'
-  notes: Imports
-  url: https://astamm.github.io/nloptr/index.html
-  repository: https://CRAN.R-project.org/package=nloptr
-  authors:
-  - family-names: Ypma
-    given-names: Jelmer
-    email: uctpjyy@ucl.ac.uk
-  - family-names: Johnson
-    given-names: Steven G.
-  year: '2023'
-- type: software
-  title: purrr
-  abstract: 'purrr: Functional Programming Tools'
-  notes: Imports
-  url: https://purrr.tidyverse.org/
-  repository: https://CRAN.R-project.org/package=purrr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-    orcid: https://orcid.org/0000-0003-4757-117X
-  - family-names: Henry
-    given-names: Lionel
-    email: lionel@rstudio.com
-  year: '2023'
-- type: software
-  title: rlang
-  abstract: 'rlang: Functions for Base Types and Core R and ''Tidyverse'' Features'
-  notes: Imports
-  url: https://rlang.r-lib.org
-  repository: https://CRAN.R-project.org/package=rlang
-  authors:
-  - family-names: Henry
-    given-names: Lionel
-    email: lionel@posit.co
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  year: '2023'
-- type: software
-  title: rstudioapi
-  abstract: 'rstudioapi: Safely Access the RStudio API'
-  notes: Imports
-  url: https://rstudio.github.io/rstudioapi/
-  repository: https://CRAN.R-project.org/package=rstudioapi
-  authors:
-  - family-names: Ushey
-    given-names: Kevin
-    email: kevin@rstudio.com
-  - family-names: Allaire
-    given-names: JJ
-    email: jj@rstudio.com
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-  - family-names: Ritchie
-    given-names: Gary
-    email: gary@rstudio.com
-  year: '2023'
-- type: software
-  title: stringr
-  abstract: 'stringr: Simple, Consistent Wrappers for Common String Operations'
-  notes: Imports
-  url: https://stringr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=stringr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-  year: '2023'
-- type: software
-  title: tibble
-  abstract: 'tibble: Simple Data Frames'
-  notes: Imports
-  url: https://tibble.tidyverse.org/
-  repository: https://CRAN.R-project.org/package=tibble
-  authors:
-  - family-names: Müller
-    given-names: Kirill
-    email: kirill@cynkra.com
-    orcid: https://orcid.org/0000-0002-1416-3412
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@rstudio.com
-  year: '2023'
-- type: software
-  title: tictoc
-  abstract: 'tictoc: Functions for Timing R Scripts, as Well as Implementations of
-    "Stack" and "StackList" Structures'
-  notes: Imports
-  url: https://github.com/jabiru/tictoc
-  repository: https://CRAN.R-project.org/package=tictoc
-  authors:
-  - family-names: Izrailev
-    given-names: Sergei
-  year: '2023'
-- type: software
-  title: ApsimOnR
-  abstract: 'ApsimOnR: Running the Apsim model with parameters forcing'
-  notes: Suggests
-  url: https://github.com/ApsimOnR
-  authors:
-  - family-names: Holzworth
-    given-names: Drew
-    email: drew.holzworth@csiro.au
-  year: '2023'
-- type: software
-  title: covr
-  abstract: 'covr: Test Coverage for Packages'
-  notes: Suggests
-  url: https://covr.r-lib.org
-  repository: https://CRAN.R-project.org/package=covr
-  authors:
-  - family-names: Hester
-    given-names: Jim
-    email: james.f.hester@gmail.com
-  year: '2023'
-- type: software
-  title: CroPlotR
-  abstract: 'CroPlotR: A Package to Analyze Crop Model Simulations Outputs with Plots
-    and Statistics'
-  notes: Suggests
-  url: https://doi.org/10.5281/zenodo.4442330
-  authors:
-  - family-names: Vezy
-    given-names: Remi
-    email: remi.vezy@cirad.fr
-    orcid: https://orcid.org/0000-0002-0808-1461
-  - family-names: Buis
-    given-names: Samuel
-    email: samuel.buis@inrae.fr
-    orcid: https://orcid.org/0000-0002-8676-5447
-  - family-names: Lecharpentier
-    given-names: Patrice
-    email: patrice.lecharpentier@inrae.fr
-    orcid: https://orcid.org/0000-0002-4044-4322
-  - family-names: Giner
-    given-names: Michel
-    email: michel.giner@cirad.fr
-    orcid: https://orcid.org/0000-0002-9310-2377
-  year: '2023'
-- type: software
-  title: devtools
-  abstract: 'devtools: Tools to Make Developing R Packages Easier'
-  notes: Suggests
-  url: https://devtools.r-lib.org/
-  repository: https://CRAN.R-project.org/package=devtools
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-  - family-names: Hester
-    given-names: Jim
-  - family-names: Chang
-    given-names: Winston
-  - family-names: Bryan
-    given-names: Jennifer
-    email: jenny@rstudio.com
-    orcid: https://orcid.org/0000-0002-6983-2759
-  year: '2023'
-- type: software
-  title: gridExtra
-  abstract: 'gridExtra: Miscellaneous Functions for "Grid" Graphics'
-  notes: Suggests
-  repository: https://CRAN.R-project.org/package=gridExtra
-  authors:
-  - family-names: Auguie
-    given-names: Baptiste
-    email: baptiste.auguie@gmail.com
-  year: '2023'
-- type: software
-  title: knitr
-  abstract: 'knitr: A General-Purpose Package for Dynamic Report Generation in R'
-  notes: Suggests
-  url: https://yihui.org/knitr/
-  repository: https://CRAN.R-project.org/package=knitr
-  authors:
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
-  year: '2023'
-- type: software
-  title: rmarkdown
-  abstract: 'rmarkdown: Dynamic Documents for R'
-  notes: Suggests
-  url: https://pkgs.rstudio.com/rmarkdown/
-  repository: https://CRAN.R-project.org/package=rmarkdown
-  authors:
-  - family-names: Allaire
-    given-names: JJ
-    email: jj@posit.co
-  - family-names: Xie
-    given-names: Yihui
-    email: xie@yihui.name
-    orcid: https://orcid.org/0000-0003-0645-5666
-  - family-names: Dervieux
-    given-names: Christophe
-    email: cderv@posit.co
-    orcid: https://orcid.org/0000-0003-4474-2498
-  - family-names: McPherson
-    given-names: Jonathan
-    email: jonathan@posit.co
-  - family-names: Luraschi
-    given-names: Javier
-  - family-names: Ushey
-    given-names: Kevin
-    email: kevin@posit.co
-  - family-names: Atkins
-    given-names: Aron
-    email: aron@posit.co
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  - family-names: Cheng
-    given-names: Joe
-    email: joe@posit.co
-  - family-names: Chang
-    given-names: Winston
-    email: winston@posit.co
-  - family-names: Iannone
-    given-names: Richard
-    email: rich@posit.co
-    orcid: https://orcid.org/0000-0003-3925-190X
-  year: '2023'
-- type: software
-  title: spelling
-  abstract: 'spelling: Tools for Spell Checking in R'
-  notes: Suggests
-  url: https://docs.ropensci.org/spelling/
-  repository: https://CRAN.R-project.org/package=spelling
-  authors:
-  - family-names: Ooms
-    given-names: Jeroen
-    email: jeroen@berkeley.edu
-    orcid: https://orcid.org/0000-0002-4035-0289
-  - family-names: Hester
-    given-names: Jim
-    email: james.hester@rstudio.com
-  year: '2023'
-- type: software
-  title: SticsOnR
-  abstract: 'SticsOnR: Manage STICS Simulations Running the Executable or JavaStics,'
-  notes: Suggests
-  url: https://doi.org/10.5281/zenodo.4443130
-  authors:
-  - family-names: Lecharpentier
-    given-names: Patrice
-    email: patrice.lecharpentier@inrae.fr
-    orcid: https://orcid.org/0000-0002-4044-4322
-  - family-names: Vezy
-    given-names: Remi
-    email: remi.vezy@cirad.fr
-    orcid: https://orcid.org/0000-0002-0808-1461
-  - family-names: Buis
-    given-names: Samuel
-    email: samuel.buis@inrae.fr
-    orcid: https://orcid.org/0000-0002-8676-5447
-  - family-names: Giner
-    given-names: Michel
-    email: michel.giner@cirad.fr
-    orcid: https://orcid.org/0000-0002-9310-2377
-  year: '2023'
-- type: software
-  title: SticsRFiles
-  abstract: 'SticsRFiles: Read and Modify STICS Input/Output Files'
-  notes: Suggests
-  url: https://doi.org/10.5281/zenodo.4443206
-  authors:
-  - family-names: Lecharpentier
-    given-names: Patrice
-    email: patrice.lecharpentier@inrae.fr
-    orcid: https://orcid.org/0000-0002-4044-4322
-  - family-names: Vezy
-    given-names: Remi
-    email: remi.vezy@cirad.fr
-    orcid: https://orcid.org/0000-0002-0808-1461
-  - family-names: Buis
-    given-names: Samuel
-    email: samuel.buis@inrae.fr
-    orcid: https://orcid.org/0000-0002-8676-5447
-  - family-names: Giner
-    given-names: Michel
-    email: michel.giner@cirad.fr
-    orcid: https://orcid.org/0000-0002-9310-2377
-  year: '2023'
-- type: software
-  title: testthat
-  abstract: 'testthat: Unit Testing for R'
-  notes: Suggests
-  url: https://testthat.r-lib.org
-  repository: https://CRAN.R-project.org/package=testthat
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  year: '2023'
-  version: '>= 2.1.0'
-- type: software
-  title: tidyr
-  abstract: 'tidyr: Tidy Messy Data'
-  notes: Suggests
-  url: https://tidyr.tidyverse.org
-  repository: https://CRAN.R-project.org/package=tidyr
-  authors:
-  - family-names: Wickham
-    given-names: Hadley
-    email: hadley@posit.co
-  - family-names: Vaughan
-    given-names: Davis
-    email: davis@posit.co
-  - family-names: Girlich
-    given-names: Maximilian
-  year: '2023'
+  - type: software
+    title: "R: A Language and Environment for Statistical Computing"
+    notes: Depends
+    url: https://www.R-project.org/
+    authors:
+      - name: R Core Team
+    location:
+      name: Vienna, Austria
+    year: "2023"
+    institution:
+      name: R Foundation for Statistical Computing
+    version: ">= 4.0.0"
+  - type: software
+    title: BayesianTools
+    abstract: "BayesianTools: General-Purpose MCMC and SMC Samplers and Tools for
+      Bayesian Statistics"
+    notes: Imports
+    url: https://github.com/florianhartig/BayesianTools
+    repository: https://CRAN.R-project.org/package=BayesianTools
+    authors:
+      - family-names: Hartig
+        given-names: Florian
+        email: florian.hartig@biologie.uni-regensburg.de
+        orcid: https://orcid.org/0000-0002-6255-9059
+      - family-names: Minunno
+        given-names: Francesco
+      - family-names: Paul
+        given-names: Stefan
+    year: "2023"
+  - type: software
+    title: crayon
+    abstract: "crayon: Colored Terminal Output"
+    notes: Imports
+    url: https://github.com/r-lib/crayon#readme
+    repository: https://CRAN.R-project.org/package=crayon
+    authors:
+      - family-names: Csárdi
+        given-names: Gábor
+        email: csardi.gabor@gmail.com
+    year: "2023"
+  - type: software
+    title: doParallel
+    abstract: "doParallel: Foreach Parallel Adaptor for the 'parallel' Package"
+    notes: Imports
+    url: https://github.com/RevolutionAnalytics/doparallel
+    repository: https://CRAN.R-project.org/package=doParallel
+    authors:
+      - family-names: Corporation
+        given-names: Microsoft
+      - family-names: Weston
+        given-names: Steve
+    year: "2023"
+  - type: software
+    title: dplyr
+    abstract: "dplyr: A Grammar of Data Manipulation"
+    notes: Imports
+    url: https://dplyr.tidyverse.org
+    repository: https://CRAN.R-project.org/package=dplyr
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@posit.co
+        orcid: https://orcid.org/0000-0003-4757-117X
+      - family-names: François
+        given-names: Romain
+        orcid: https://orcid.org/0000-0002-2444-4226
+      - family-names: Henry
+        given-names: Lionel
+      - family-names: Müller
+        given-names: Kirill
+        orcid: https://orcid.org/0000-0002-1416-3412
+      - family-names: Vaughan
+        given-names: Davis
+        email: davis@posit.co
+        orcid: https://orcid.org/0000-0003-4777-038X
+    year: "2023"
+  - type: software
+    title: ggplot2
+    abstract: "ggplot2: Create Elegant Data Visualisations Using the Grammar of Graphics"
+    notes: Imports
+    url: https://ggplot2.tidyverse.org
+    repository: https://CRAN.R-project.org/package=ggplot2
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@posit.co
+        orcid: https://orcid.org/0000-0003-4757-117X
+      - family-names: Chang
+        given-names: Winston
+        orcid: https://orcid.org/0000-0002-1576-2126
+      - family-names: Henry
+        given-names: Lionel
+      - family-names: Pedersen
+        given-names: Thomas Lin
+        email: thomas.pedersen@posit.co
+        orcid: https://orcid.org/0000-0002-5147-4711
+      - family-names: Takahashi
+        given-names: Kohske
+      - family-names: Wilke
+        given-names: Claus
+        orcid: https://orcid.org/0000-0002-7470-9261
+      - family-names: Woo
+        given-names: Kara
+        orcid: https://orcid.org/0000-0002-5125-4188
+      - family-names: Yutani
+        given-names: Hiroaki
+        orcid: https://orcid.org/0000-0002-3385-7233
+      - family-names: Dunnington
+        given-names: Dewey
+        orcid: https://orcid.org/0000-0002-9415-4582
+    year: "2023"
+  - type: software
+    title: lhs
+    abstract: "lhs: Latin Hypercube Samples"
+    notes: Imports
+    url: https://github.com/bertcarnell/lhs
+    repository: https://CRAN.R-project.org/package=lhs
+    authors:
+      - family-names: Carnell
+        given-names: Rob
+        email: bertcarnell@gmail.com
+    year: "2023"
+  - type: software
+    title: lifecycle
+    abstract: "lifecycle: Manage the Life Cycle of your Package Functions"
+    notes: Imports
+    url: https://lifecycle.r-lib.org/
+    repository: https://CRAN.R-project.org/package=lifecycle
+    authors:
+      - family-names: Henry
+        given-names: Lionel
+        email: lionel@rstudio.com
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@rstudio.com
+        orcid: https://orcid.org/0000-0003-4757-117X
+    year: "2023"
+  - type: software
+    title: lubridate
+    abstract: "lubridate: Make Dealing with Dates a Little Easier"
+    notes: Imports
+    url: https://lubridate.tidyverse.org
+    repository: https://CRAN.R-project.org/package=lubridate
+    authors:
+      - family-names: Spinu
+        given-names: Vitalie
+        email: spinuvit@gmail.com
+      - family-names: Grolemund
+        given-names: Garrett
+      - family-names: Wickham
+        given-names: Hadley
+    year: "2023"
+  - type: software
+    title: methods
+    abstract: "R: A Language and Environment for Statistical Computing"
+    notes: Imports
+    authors:
+      - name: R Core Team
+    location:
+      name: Vienna, Austria
+    year: "2023"
+    institution:
+      name: R Foundation for Statistical Computing
+  - type: software
+    title: nloptr
+    abstract: "nloptr: R Interface to NLopt"
+    notes: Imports
+    url: https://astamm.github.io/nloptr/index.html
+    repository: https://CRAN.R-project.org/package=nloptr
+    authors:
+      - family-names: Ypma
+        given-names: Jelmer
+        email: uctpjyy@ucl.ac.uk
+      - family-names: Johnson
+        given-names: Steven G.
+    year: "2023"
+  - type: software
+    title: purrr
+    abstract: "purrr: Functional Programming Tools"
+    notes: Imports
+    url: https://purrr.tidyverse.org/
+    repository: https://CRAN.R-project.org/package=purrr
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@rstudio.com
+        orcid: https://orcid.org/0000-0003-4757-117X
+      - family-names: Henry
+        given-names: Lionel
+        email: lionel@rstudio.com
+    year: "2023"
+  - type: software
+    title: rlang
+    abstract: "rlang: Functions for Base Types and Core R and 'Tidyverse' Features"
+    notes: Imports
+    url: https://rlang.r-lib.org
+    repository: https://CRAN.R-project.org/package=rlang
+    authors:
+      - family-names: Henry
+        given-names: Lionel
+        email: lionel@posit.co
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@posit.co
+    year: "2023"
+  - type: software
+    title: rstudioapi
+    abstract: "rstudioapi: Safely Access the RStudio API"
+    notes: Imports
+    url: https://rstudio.github.io/rstudioapi/
+    repository: https://CRAN.R-project.org/package=rstudioapi
+    authors:
+      - family-names: Ushey
+        given-names: Kevin
+        email: kevin@rstudio.com
+      - family-names: Allaire
+        given-names: JJ
+        email: jj@rstudio.com
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@rstudio.com
+      - family-names: Ritchie
+        given-names: Gary
+        email: gary@rstudio.com
+    year: "2023"
+  - type: software
+    title: stringr
+    abstract: "stringr: Simple, Consistent Wrappers for Common String Operations"
+    notes: Imports
+    url: https://stringr.tidyverse.org
+    repository: https://CRAN.R-project.org/package=stringr
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@rstudio.com
+    year: "2023"
+  - type: software
+    title: tibble
+    abstract: "tibble: Simple Data Frames"
+    notes: Imports
+    url: https://tibble.tidyverse.org/
+    repository: https://CRAN.R-project.org/package=tibble
+    authors:
+      - family-names: Müller
+        given-names: Kirill
+        email: kirill@cynkra.com
+        orcid: https://orcid.org/0000-0002-1416-3412
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@rstudio.com
+    year: "2023"
+  - type: software
+    title: tictoc
+    abstract: "tictoc: Functions for Timing R Scripts, as Well as Implementations of
+      \"Stack\" and \"StackList\" Structures"
+    notes: Imports
+    url: https://github.com/jabiru/tictoc
+    repository: https://CRAN.R-project.org/package=tictoc
+    authors:
+      - family-names: Izrailev
+        given-names: Sergei
+    year: "2023"
+  - type: software
+    title: ApsimOnR
+    abstract: "ApsimOnR: Running the Apsim model with parameters forcing"
+    notes: Suggests
+    url: https://github.com/ApsimOnR
+    authors:
+      - family-names: Holzworth
+        given-names: Drew
+        email: drew.holzworth@csiro.au
+    year: "2023"
+  - type: software
+    title: covr
+    abstract: "covr: Test Coverage for Packages"
+    notes: Suggests
+    url: https://covr.r-lib.org
+    repository: https://CRAN.R-project.org/package=covr
+    authors:
+      - family-names: Hester
+        given-names: Jim
+        email: james.f.hester@gmail.com
+    year: "2023"
+  - type: software
+    title: CroPlotR
+    abstract: "CroPlotR: A Package to Analyze Crop Model Simulations Outputs with
+      Plots and Statistics"
+    notes: Suggests
+    url: https://doi.org/10.5281/zenodo.4442330
+    authors:
+      - family-names: Vezy
+        given-names: Remi
+        email: remi.vezy@cirad.fr
+        orcid: https://orcid.org/0000-0002-0808-1461
+      - family-names: Buis
+        given-names: Samuel
+        email: samuel.buis@inrae.fr
+        orcid: https://orcid.org/0000-0002-8676-5447
+      - family-names: Lecharpentier
+        given-names: Patrice
+        email: patrice.lecharpentier@inrae.fr
+        orcid: https://orcid.org/0000-0002-4044-4322
+      - family-names: Giner
+        given-names: Michel
+        email: michel.giner@cirad.fr
+        orcid: https://orcid.org/0000-0002-9310-2377
+    year: "2023"
+  - type: software
+    title: devtools
+    abstract: "devtools: Tools to Make Developing R Packages Easier"
+    notes: Suggests
+    url: https://devtools.r-lib.org/
+    repository: https://CRAN.R-project.org/package=devtools
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+      - family-names: Hester
+        given-names: Jim
+      - family-names: Chang
+        given-names: Winston
+      - family-names: Bryan
+        given-names: Jennifer
+        email: jenny@rstudio.com
+        orcid: https://orcid.org/0000-0002-6983-2759
+    year: "2023"
+  - type: software
+    title: gridExtra
+    abstract: "gridExtra: Miscellaneous Functions for \"Grid\" Graphics"
+    notes: Suggests
+    repository: https://CRAN.R-project.org/package=gridExtra
+    authors:
+      - family-names: Auguie
+        given-names: Baptiste
+        email: baptiste.auguie@gmail.com
+    year: "2023"
+  - type: software
+    title: knitr
+    abstract: "knitr: A General-Purpose Package for Dynamic Report Generation in R"
+    notes: Suggests
+    url: https://yihui.org/knitr/
+    repository: https://CRAN.R-project.org/package=knitr
+    authors:
+      - family-names: Xie
+        given-names: Yihui
+        email: xie@yihui.name
+        orcid: https://orcid.org/0000-0003-0645-5666
+    year: "2023"
+  - type: software
+    title: rmarkdown
+    abstract: "rmarkdown: Dynamic Documents for R"
+    notes: Suggests
+    url: https://pkgs.rstudio.com/rmarkdown/
+    repository: https://CRAN.R-project.org/package=rmarkdown
+    authors:
+      - family-names: Allaire
+        given-names: JJ
+        email: jj@posit.co
+      - family-names: Xie
+        given-names: Yihui
+        email: xie@yihui.name
+        orcid: https://orcid.org/0000-0003-0645-5666
+      - family-names: Dervieux
+        given-names: Christophe
+        email: cderv@posit.co
+        orcid: https://orcid.org/0000-0003-4474-2498
+      - family-names: McPherson
+        given-names: Jonathan
+        email: jonathan@posit.co
+      - family-names: Luraschi
+        given-names: Javier
+      - family-names: Ushey
+        given-names: Kevin
+        email: kevin@posit.co
+      - family-names: Atkins
+        given-names: Aron
+        email: aron@posit.co
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@posit.co
+      - family-names: Cheng
+        given-names: Joe
+        email: joe@posit.co
+      - family-names: Chang
+        given-names: Winston
+        email: winston@posit.co
+      - family-names: Iannone
+        given-names: Richard
+        email: rich@posit.co
+        orcid: https://orcid.org/0000-0003-3925-190X
+    year: "2023"
+  - type: software
+    title: spelling
+    abstract: "spelling: Tools for Spell Checking in R"
+    notes: Suggests
+    url: https://docs.ropensci.org/spelling/
+    repository: https://CRAN.R-project.org/package=spelling
+    authors:
+      - family-names: Ooms
+        given-names: Jeroen
+        email: jeroen@berkeley.edu
+        orcid: https://orcid.org/0000-0002-4035-0289
+      - family-names: Hester
+        given-names: Jim
+        email: james.hester@rstudio.com
+    year: "2023"
+  - type: software
+    title: SticsOnR
+    abstract: "SticsOnR: Manage STICS Simulations Running the Executable or JavaStics,"
+    notes: Suggests
+    url: https://doi.org/10.5281/zenodo.4443130
+    authors:
+      - family-names: Lecharpentier
+        given-names: Patrice
+        email: patrice.lecharpentier@inrae.fr
+        orcid: https://orcid.org/0000-0002-4044-4322
+      - family-names: Vezy
+        given-names: Remi
+        email: remi.vezy@cirad.fr
+        orcid: https://orcid.org/0000-0002-0808-1461
+      - family-names: Buis
+        given-names: Samuel
+        email: samuel.buis@inrae.fr
+        orcid: https://orcid.org/0000-0002-8676-5447
+      - family-names: Giner
+        given-names: Michel
+        email: michel.giner@cirad.fr
+        orcid: https://orcid.org/0000-0002-9310-2377
+    year: "2023"
+  - type: software
+    title: SticsRFiles
+    abstract: "SticsRFiles: Read and Modify STICS Input/Output Files"
+    notes: Suggests
+    url: https://doi.org/10.5281/zenodo.4443206
+    authors:
+      - family-names: Lecharpentier
+        given-names: Patrice
+        email: patrice.lecharpentier@inrae.fr
+        orcid: https://orcid.org/0000-0002-4044-4322
+      - family-names: Vezy
+        given-names: Remi
+        email: remi.vezy@cirad.fr
+        orcid: https://orcid.org/0000-0002-0808-1461
+      - family-names: Buis
+        given-names: Samuel
+        email: samuel.buis@inrae.fr
+        orcid: https://orcid.org/0000-0002-8676-5447
+      - family-names: Giner
+        given-names: Michel
+        email: michel.giner@cirad.fr
+        orcid: https://orcid.org/0000-0002-9310-2377
+    year: "2023"
+  - type: software
+    title: testthat
+    abstract: "testthat: Unit Testing for R"
+    notes: Suggests
+    url: https://testthat.r-lib.org
+    repository: https://CRAN.R-project.org/package=testthat
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@posit.co
+    year: "2023"
+    version: ">= 2.1.0"
+  - type: software
+    title: tidyr
+    abstract: "tidyr: Tidy Messy Data"
+    notes: Suggests
+    url: https://tidyr.tidyverse.org
+    repository: https://CRAN.R-project.org/package=tidyr
+    authors:
+      - family-names: Wickham
+        given-names: Hadley
+        email: hadley@posit.co
+      - family-names: Vaughan
+        given-names: Davis
+        email: davis@posit.co
+      - family-names: Girlich
+        given-names: Maximilian
+    year: "2023"


### PR DESCRIPTION
The release on Zenodo is erroring with the following error: 

```json
{
    "error_id": "9183bbcc5d424f26a98046ed28ecf052",
    "errors": "while scanning for the next token\nfound character \u0027\\t\u0027 that cannot start any token\n  in \"\u003cunicode string\u003e\", line 17, column 1:\n    \t  including AgMIP calibration p ... \n    ^"
}
```

See: https://zenodo.org/account/settings/github/repository/SticsRPacks/CroptimizR if you have access.

This PR fixes the CITATION.cff formating, which seems to be the origin of the error.
